### PR TITLE
Update runtime version from 42 to 44

### DIFF
--- a/io.github.jliljebl.Flowblade.yaml
+++ b/io.github.jliljebl.Flowblade.yaml
@@ -1,5 +1,4 @@
 app-id: io.github.jliljebl.Flowblade
-default-branch: stable
 runtime: org.gnome.Platform
 runtime-version: '44'
 sdk: org.gnome.Sdk

--- a/io.github.jliljebl.Flowblade.yaml
+++ b/io.github.jliljebl.Flowblade.yaml
@@ -183,8 +183,8 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://files.pythonhosted.org/packages/ff/59/d3f6d46aa1fd220d020bdd61e76ca51f6548c6ad6d24ddb614f4037cf49d/numpy-1.17.4.zip
-        sha256: f58913e9227400f1395c7b800503ebfdb0772f1c33ff8cb4d6451c06cabdf316
+        url: https://files.pythonhosted.org/packages/e4/a9/6704bb5e1d1d778d3a6ee1278a8d8134f0db160e09d52863a24edb58eab5/numpy-1.24.2.tar.gz
+        sha256: 003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22
 
   - name: gmic
     buildsystem: cmake-ninja

--- a/io.github.jliljebl.Flowblade.yaml
+++ b/io.github.jliljebl.Flowblade.yaml
@@ -18,14 +18,14 @@ finish-args:
 add-extensions:
   org.freedesktop.LinuxAudio.Plugins:
     directory: extensions/Plugins
-    version: '21.08'
+    version: '22.08'
     add-ld-path: lib
     merge-dirs: ladspa
     subdirectories: true
     no-autodownload: true
   org.freedesktop.LinuxAudio.Plugins.swh:
     directory: extensions/Plugins/swh
-    version: '21.08'
+    version: '22.08'
     add-ld-path: lib
     merge-dirs: ladspa
     autodelete: false
@@ -186,19 +186,6 @@ modules:
       - type: archive
         url: https://files.pythonhosted.org/packages/ff/59/d3f6d46aa1fd220d020bdd61e76ca51f6548c6ad6d24ddb614f4037cf49d/numpy-1.17.4.zip
         sha256: f58913e9227400f1395c7b800503ebfdb0772f1c33ff8cb4d6451c06cabdf316
-
-  - name: jack2
-    buildsystem: simple
-    build-commands:
-      - ./waf configure --prefix=/app --htmldir=/app/share/doc/jack/ --classic
-      - ./waf build -j $FLATPAK_BUILDER_N_JOBS
-      - ./waf install
-    cleanup:
-      - '*'
-    sources:
-      - type: archive
-        url: https://github.com/jackaudio/jack2/releases/download/v1.9.14/v1.9.14.tar.gz
-        sha256: a20a32366780c0061fd58fbb5f09e514ea9b7ce6e53b080a44b11a558a83217c
 
   - name: gmic
     buildsystem: cmake-ninja

--- a/io.github.jliljebl.Flowblade.yaml
+++ b/io.github.jliljebl.Flowblade.yaml
@@ -1,7 +1,7 @@
 app-id: io.github.jliljebl.Flowblade
 default-branch: stable
 runtime: org.gnome.Platform
-runtime-version: '42'
+runtime-version: '44'
 sdk: org.gnome.Sdk
 command: flowblade
 finish-args:

--- a/io.github.jliljebl.Flowblade.yaml
+++ b/io.github.jliljebl.Flowblade.yaml
@@ -177,8 +177,8 @@ modules:
   - name: numpy
     buildsystem: simple
     build-commands:
-      - mkdir -p /app/lib/python3.9/site-packages
-      - CFLAGS='-L/usr/lib -Lbuild/temp.linux-x86_64-3.4 -I/usr/include -I/usr/include/python3.9/' CXX=/usr/bin/g++ CC=/usr/bin/gcc PYTHONUSERBASE=/app/ python3 setup.py install --prefix=/app
+      - mkdir -p /app/lib/python3.10/site-packages
+      - CFLAGS='-L/usr/lib -Lbuild/temp.linux-x86_64-3.4 -I/usr/include -I/usr/include/python3.10/' CXX=/usr/bin/g++ CC=/usr/bin/gcc PYTHONUSERBASE=/app/ python3 setup.py install --prefix=/app
     cleanup:
       - /bin
     sources:
@@ -209,8 +209,8 @@ modules:
         PYTHON: python3
       cxxflags: -L/app/lib
     post-install:
-      - install -Dm644 src/swig/python/mlt.py /app/lib/python3.9/site-packages/mlt.py
-      - install src/swig/python/_mlt.so /app/lib/python3.9/site-packages/_mlt.so
+      - install -Dm644 src/swig/python/mlt.py /app/lib/python3.10/site-packages/mlt.py
+      - install src/swig/python/_mlt.so /app/lib/python3.10/site-packages/_mlt.so
     cleanup:
       - /bin
     sources:


### PR DESCRIPTION
Version 42 is end-of-life as of March 21, 2023. As far as I can tell this change doesn't introduce any problems, but if anyone can double check I would appreciate it.