### PR TITLE
Fix launching for Gnome 48.

### DIFF
--- a/io.github.jliljebl.Flowblade.yaml
+++ b/io.github.jliljebl.Flowblade.yaml
@@ -1,7 +1,7 @@
 app-id: io.github.jliljebl.Flowblade
 default-branch: stable
 runtime: org.gnome.Platform
-runtime-version: '46'
+runtime-version: '48'
 sdk: org.gnome.Sdk
 command: flowblade
 finish-args:
@@ -321,16 +321,16 @@ modules:
   - name: numpy
     buildsystem: simple
     build-commands:
-      - mkdir -p /app/lib/python3.10/site-packages
-      - CFLAGS='-L/usr/lib -Lbuild/temp.linux-x86_64-3.4 -I/usr/include -I/usr/include/python3.10/'
-        CXX=/usr/bin/g++ CC=/usr/bin/gcc PYTHONUSERBASE=/app/ python3 setup.py install
-        --prefix=/app
+      - ./vendored-meson/meson/meson.py setup builddir --buildtype=debugoptimized
+        --prefix=${FLATPAK_DEST}
+      - cd builddir && ninja
+      - cd builddir && ninja install
     cleanup:
       - /bin
     sources:
       - type: archive
-        url: https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz
-        sha256: 2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010
+        url: https://github.com/numpy/numpy/releases/download/v2.2.5/numpy-2.2.5.tar.gz
+        sha256: a9c0d994680cd991b1cb772e8b297340085466a6fe964bc9d4e80f5e2f43c291
 
   - name: gmic
     buildsystem: cmake-ninja

--- a/io.github.jliljebl.Flowblade.yaml
+++ b/io.github.jliljebl.Flowblade.yaml
@@ -38,6 +38,8 @@ cleanup:
   - /share/pkgconfig
   - '*.a'
   - '*.la'
+cleanup-commands:
+  - "sed -i -e 's/#!python/#!\\/usr\\/bin\\/python3/g' /app/bin/flowblade"
 modules:
   - shared-modules/gtk2/gtk2.json
   - shared-modules/dbus-glib/dbus-glib.json


### PR DESCRIPTION
Version of setuptools used by Gnome 48 breaks application launching, see:  https://gitlab.archlinux.org/archlinux/packaging/packages/python-setuptools/-/issues/4

This patch fixes launching by editing first line of launch script.