### PR TITLE
Update runtime to GNOME 49

### DIFF
--- a/io.github.jliljebl.Flowblade.yaml
+++ b/io.github.jliljebl.Flowblade.yaml
@@ -1,7 +1,6 @@
 app-id: io.github.jliljebl.Flowblade
-default-branch: stable
 runtime: org.gnome.Platform
-runtime-version: '48'
+runtime-version: '49'
 sdk: org.gnome.Sdk
 command: flowblade
 finish-args:
@@ -17,14 +16,14 @@ finish-args:
 add-extensions:
   org.freedesktop.LinuxAudio.Plugins:
     directory: extensions/Plugins
-    version: '24.08'
+    version: '25.08'
     add-ld-path: lib
     merge-dirs: ladspa
     subdirectories: true
     no-autodownload: true
   org.freedesktop.LinuxAudio.Plugins.swh:
     directory: extensions/Plugins/swh
-    version: '24.08'
+    version: '25.08'
     add-ld-path: lib
     merge-dirs: ladspa
     autodelete: false
@@ -38,12 +37,9 @@ cleanup:
   - /share/pkgconfig
   - '*.a'
   - '*.la'
-cleanup-commands:
-  - sed -i -e 's/#!python/#!\/usr\/bin\/python3/g' /app/bin/flowblade
 modules:
   - shared-modules/gtk2/gtk2.json
   - shared-modules/dbus-glib/dbus-glib.json
-  - shared-modules/libusb/libusb.json
 
   - name: eigen
     buildsystem: cmake-ninja
@@ -57,31 +53,6 @@ modules:
         url: https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2
         sha256: b4c198460eba6f28d34894e3a5710998818515104d6e74e5cc331ce31e46e626
 
-  - name: fftw-float
-    config-opts:
-      - --disable-doc
-      - --enable-shared
-      - --disable-static
-      - --enable-threads
-      - --enable-float
-    build-options:
-      arch:
-        x86_64:
-          config-opts:
-            - --enable-avx
-            - --enable-openmp
-            - --enable-sse
-        aarch64:
-          config-opts:
-            - --enable-neon
-            - --enable-openmp
-    cleanup:
-      - /bin
-    sources:
-      - type: archive
-        url: http://www.fftw.org/fftw-3.3.10.tar.gz
-        sha256: 56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467
-
   - name: zimg
     buildsystem: autotools
     sources:
@@ -90,11 +61,14 @@ modules:
         sha256: a9a0226bf85e0d83c41a8ebe4e3e690e1348682f6a2a7838f1b8cbff1b799bcf
 
   - name: gavl
+    build-options:
+      cflags: -std=gnu18
     config-opts:
       - --without-doxygen
       - --disable-static
       - --enable-shared
       - --with-cpuflags=none
+    no-autogen: true
     sources:
       - type: archive
         url: https://salsa.debian.org/multimedia-team/gavl/-/archive/upstream/2.0.0_svngit.20240111.a5dd20c/gavl-upstream-2.0.0_svngit.20240111.a5dd20c.tar.gz
@@ -102,9 +76,6 @@ modules:
       - type: shell
         commands:
           - cp -p /usr/share/automake-*/config.{sub,guess} .
-      - type: script
-        dest-filename: autogen.sh
-        commands:
           - autoreconf -vfi
 
   - name: frei0r-plugins
@@ -112,6 +83,7 @@ modules:
     builddir: true
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     sources:
       - type: git
         url: https://github.com/dyne/frei0r.git
@@ -136,6 +108,7 @@ modules:
     builddir: true
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     sources:
       - type: archive
         url: https://github.com/georgmartius/vid.stab/archive/v1.1.1.tar.gz
@@ -148,14 +121,16 @@ modules:
 
   - name: pillow
     buildsystem: simple
+    build-options:
+      cflags: -std=gnu18
     build-commands:
       - python3 setup.py install --prefix=/app --root=/
     cleanup:
       - /bin
     sources:
       - type: archive
-        url: https://github.com/python-pillow/Pillow/archive/refs/tags/10.2.0.tar.gz
-        sha256: fe695f6fa8bbc341b9044b6553a32d84cf6d6ea0de104396aece85e454c7cbc2
+        url: https://github.com/python-pillow/Pillow/archive/refs/tags/10.4.0.tar.gz
+        sha256: e70284e8605a5b7ccb37e5bfd4634598ca2c43c7f2c353572351ccf72c031004
 
   - name: usb1
     buildsystem: simple
@@ -208,29 +183,19 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - -DENABLE_CLI=OFF
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     sources:
       - type: archive
         url: https://deb.debian.org/debian/pool/main/x/x265/x265_3.5.orig.tar.gz
         sha256: e70a3335cacacbba0b3a20ec6fecd6783932288ebc8163ad74bcc9606477cae8
-
-  - name: nv-codec-headers
-    cleanup:
-      - '*'
-    no-autogen: true
-    make-install-args:
-      - PREFIX=/app
-    sources:
-      - type: git
-        url: https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
-        commit: 43d91706e097565f57b311e567f0219838bcc2f6
-        tag: n11.1.5.3
+      - type: patch
+        path: patches/x265-cmake.patch
 
   - name: aom
     buildsystem: cmake-ninja
     builddir: true
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
-      - -DCMAKE_INSTALL_PREFIX=/app
       - -DBUILD_SHARED_LIBS=1
       - -DENABLE_DOCS=0
       - -DENABLE_EXAMPLES=0
@@ -277,6 +242,7 @@ modules:
       - -DBUILD_TESTING=OFF
       - -DBUILD_APPS=OFF
       - -DENABLE_AVX512=ON
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     sources:
       - type: git
         url: https://gitlab.com/AOMediaCodec/SVT-AV1.git
@@ -405,8 +371,8 @@ modules:
       - /lib/pkgconfig
     sources:
       - type: archive
-        url: https://github.com/libsdl-org/SDL/releases/download/release-2.30.10/SDL2-2.30.10.tar.gz
-        sha256: f59adf36a0fcf4c94198e7d3d776c1b3824211ab7aeebeb31fe19836661196aa
+        url: https://github.com/libsdl-org/SDL/releases/download/release-2.32.8/SDL2-2.32.8.tar.gz
+        sha256: 0ca83e9c9b31e18288c7ec811108e58bac1f1bb5ec6577ad386830eac51c787e
 
   - name: mlt
     buildsystem: cmake-ninja
@@ -424,7 +390,6 @@ modules:
     build-options:
       env:
         PYTHON: python3
-      cxxflags: -L/app/lib
     cleanup:
       - /bin
     sources:

--- a/patches/x265-cmake.patch
+++ b/patches/x265-cmake.patch
@@ -1,0 +1,20 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 1d1a613..c60431b 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -7,13 +7,13 @@ if(NOT CMAKE_BUILD_TYPE)
+ endif()
+ message(STATUS "cmake version ${CMAKE_VERSION}")
+ if(POLICY CMP0025)
+-    cmake_policy(SET CMP0025 OLD) # report Apple's Clang as just Clang
++    cmake_policy(SET CMP0025 NEW) # report Apple's Clang as just Clang
+ endif()
+ if(POLICY CMP0042)
+     cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH
+ endif()
+ if(POLICY CMP0054)
+-    cmake_policy(SET CMP0054 OLD) # Only interpret if() arguments as variables or keywords when unquoted
++    cmake_policy(SET CMP0054 NEW) # Only interpret if() arguments as variables or keywords when unquoted
+ endif()
+ 
+ project (x265)


### PR DESCRIPTION
- Remove libusb (it's in the runtime)
- Remove nv-codec-header (it's in the runtime)
- Remove SDL2 (it's in the runtime)
- Remove duplicatw fftw3f
- Remove unecessary "sed"
- Add CMake workarounds and patches