### PR TITLE
Remove unneeded gtk2 shared module

### DIFF
--- a/io.github.jliljebl.Flowblade.yaml
+++ b/io.github.jliljebl.Flowblade.yaml
@@ -38,7 +38,6 @@ cleanup:
   - '*.a'
   - '*.la'
 modules:
-  - shared-modules/gtk2/gtk2.json
   - shared-modules/dbus-glib/dbus-glib.json
 
   - name: eigen


### PR DESCRIPTION
This one was for Arc Dark theme and is no longer needed. 